### PR TITLE
module_updater: update DB if version missmatch

### DIFF
--- a/lib/module_updater.rb
+++ b/lib/module_updater.rb
@@ -47,8 +47,8 @@ class ModuleUpdater
 
       RemoteModule.db.transaction do
         libs.each do |name, versions|
-          versions = pick_best_versions(versions)
-          if changed_modules[name] && (versions|changed_modules[name]).size == versions.size
+          versions = pick_best_versions(versions).sort
+          if changed_modules[name] && (changed_modules[name].sort == versions)
             changed_modules.delete(name)
           elsif changed_modules[name]
             store[name] = versions


### PR DESCRIPTION
Some background:
* versions = array of all known versions for a module from the forge
* changed_modules[name] = array of all known version for a module from the database

We In the past we compared union(?) count of version from forge + DB vs from the forge. If they were equal we didn't update the database.

I don't understand how that ever worked. To my understanding we would never update an existing module in the database. I changed the logic and now we compare if all versions from the forge exist in the database. Only than we won't update the database. I tested this patch on https://www.puppetmodule.info/ and it works.

However! puppetmodule.info is a fork of rubydoc.info. They still use the same logic: https://github.com/docmeta/rubydoc.info/blob/main/lib/gem_updater.rb#L59 But that's the full updater. We also own a partial updater: https://github.com/voxpupuli/puppetmodule.info/blob/d7297771646699a478ef38d39b8df600f9102dbf/lib/module_updater.rb#L79 And that doesn't exist for rubydoc at all. We run the full updater daily and the partial one hourly. That one seems to be broken as well. We didn't receive updates for months.